### PR TITLE
Improve malcontent-action reliability and reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,12 @@
-name: Build Action
+name: Check npm build
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+    branches:
+      - main
     paths:
+      - "dist/**"
       - "src/**"
       - "package.json"
       - "package-lock.json"
@@ -11,6 +14,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Only need read access for checking
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -24,15 +29,14 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Commit built files
+      - name: Check for uncommitted changes
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add dist/
-          git diff --staged --quiet || git commit -m "Build dist files"
-
-      - name: Push changes
-        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            echo "::error::Built files in dist/ are not up to date. Please run 'npm run build' locally and commit the changes."
+            echo "The following files have changes:"
+            git status --porcelain dist/
+            git diff dist/
+            exit 1
+          else
+            echo "✅ Built files are up to date"
+          fi


### PR DESCRIPTION
## Summary

This PR updates the build workflow to check for uncommitted changes instead of attempting to push to PR branches.

## Problem

The previous build workflow would fail with 403 errors when running on PRs from forks because it tried to push changes with `contents: write` permission, which isn't available for fork PRs.

## Solution

- Changed the workflow to check if `dist/` files are up to date instead of pushing
- Reduced permissions from `contents: write` to `contents: read` 
- Added `dist/` to the workflow paths to catch when built files are out of sync
- Renamed workflow to "Check npm build" to better reflect its purpose

## Behavior

When the built files in `dist/` are not up to date, the workflow will:
1. Fail with a clear error message
2. Show which files have changes
3. Display the diff
4. Instruct contributors to run `npm run build` locally and commit the changes

This approach is more appropriate for PR checks and avoids permission issues with fork PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)