### PR TITLE
light improvements to README and comments

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -19,10 +19,9 @@ jobs:
 
       - name: Run Malcontent Analysis
         id: malcontent
-        uses: ./ # In actual usage, this would be: imjasonh/malcontent-action@v1
+        uses: ./ # In actual usage, this would be: imjasonh/malcontent-action@...
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          fail-on-increase: true
 
       # NB: Could also set `fail-on-increase: false` and use `if: ${{steps.malcontent.outputs.risk-delta > 5}}` to allow some risk increase
 

--- a/.github/workflows/push-example.yml
+++ b/.github/workflows/push-example.yml
@@ -24,9 +24,6 @@ jobs:
         uses: ./ # In actual usage, this would be: imjasonh/malcontent-action@...
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Will automatically use HEAD vs HEAD~1 for diff
-          fail-on-increase: true
-          # No PR to comment on, results will go to workflow summary
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 #v3.29.0 - 11 Jun 2025

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@...
         with:
           fetch-depth: 0
       
@@ -71,7 +71,7 @@ jobs:
   malcontent:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@...
         with:
           fetch-depth: 2  # Need HEAD and HEAD~1
       
@@ -130,7 +130,7 @@ The `risk-delta` output allows you to implement custom logic based on the magnit
 # Or use different thresholds for different actions
 - name: Request security review
   if: steps.malcontent.outputs.risk-delta > 5 && steps.malcontent.outputs.risk-delta <= 10
-  uses: actions/github-script@v6
+  uses: actions/github-script@...
   with:
     script: |
       github.rest.issues.addLabels({
@@ -146,13 +146,13 @@ The `risk-delta` output allows you to implement custom logic based on the magnit
 The action generates a SARIF (Static Analysis Results Interchange Format) report that can be uploaded to GitHub Advanced Security for integration with code scanning:
 
 ```yaml
-- uses: imjasonh/malcontent-action@v1
+- uses: imjasonh/malcontent-action@...
   id: malcontent
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 
 - name: Upload SARIF
-  uses: github/codeql-action/upload-sarif@v3
+  uses: github/codeql-action/upload-sarif@...
   if: always() # Upload even if the malcontent check fails
   with:
     sarif_file: ${{ steps.malcontent.outputs.sarif-file }}


### PR DESCRIPTION
This pull request updates references to specific versions of GitHub Actions in workflow and documentation files, replacing them with ellipses (`...`) to indicate placeholders. This change simplifies the examples and makes them more adaptable to future updates.

### Updates to GitHub Actions references:

* [`.github/workflows/example.yml`](diffhunk://#diff-d6ed008bccc277977568760d40099e6ddfdc2e8d47874752724c33f2676588e3L22-L25): Removed the `fail-on-increase` parameter from the `malcontent` action and replaced the version reference with ellipses (`...`).
* [`.github/workflows/push-example.yml`](diffhunk://#diff-314f9924b3733f78cf6e0ad4ee38642ae1f57a460544fc9593954d2abf4bb141L27-L29): Removed the `fail-on-increase` parameter and additional comments about diff behavior, while replacing the version references with ellipses (`...`).

### Updates to `README.md` examples:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53): Replaced the version references for `actions/checkout` and `actions/github-script` with ellipses (`...`) in multiple examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R74) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R133)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R155): Updated the SARIF upload example to replace version references for `imjasonh/malcontent-action` and `github/codeql-action` with ellipses (`...`).