### PR TITLE
Update repository references

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Run Malcontent Analysis
         id: malcontent
-        uses: ./ # In actual usage, this would be: imjasonh/malcontent-action@...
+        uses: ./ # In actual usage, this would be: chainguard-dev/malcontent-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/push-example.yml
+++ b/.github/workflows/push-example.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run Malcontent Diff
         id: malcontent
-        uses: ./ # In actual usage, this would be: imjasonh/malcontent-action@...
+        uses: ./ # In actual usage, this would be: chainguard-dev/malcontent-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0
       
-J      - uses: imjasonh/malcontent-action...
+      - uses: chainguard-dev/malcontent-action...
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -75,7 +75,7 @@ jobs:
         with:
           fetch-depth: 2  # Need HEAD and HEAD~1
       
-      - uses: imjasonh/malcontent-action@...
+      - uses: chainguard-dev/malcontent-action@...
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -107,7 +107,7 @@ jobs:
 The `risk-delta` output allows you to implement custom logic based on the magnitude of security changes:
 
 ```yaml
-- uses: imjasonh/malcontent-action@...
+- uses: chainguard-dev/malcontent-action@...
   id: malcontent
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -146,7 +146,7 @@ The `risk-delta` output allows you to implement custom logic based on the magnit
 The action generates a SARIF (Static Analysis Results Interchange Format) report that can be uploaded to GitHub Advanced Security for integration with code scanning:
 
 ```yaml
-- uses: imjasonh/malcontent-action@...
+- uses: chainguard-dev/malcontent-action@...
   id: malcontent
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jason/malcontent-action.git"
+    "url": "git+https://github.com/chainguard-dev/malcontent-action.git"
   },
   "keywords": [
     "github",


### PR DESCRIPTION
This pull request updates references to the `malcontent-action` GitHub Action and its repository URL to reflect its new ownership under `chainguard-dev`. The changes ensure consistency across workflow files, documentation, and package metadata.

### Updates to GitHub Action references:

* [`.github/workflows/example.yml`](diffhunk://#diff-d6ed008bccc277977568760d40099e6ddfdc2e8d47874752724c33f2676588e3L22-R22): Updated the `uses` field to reference `chainguard-dev/malcontent-action@v1` instead of `imjasonh/malcontent-action`.
* [`.github/workflows/push-example.yml`](diffhunk://#diff-314f9924b3733f78cf6e0ad4ee38642ae1f57a460544fc9593954d2abf4bb141L24-R24): Updated the `uses` field to reference `chainguard-dev/malcontent-action@v1` instead of `imjasonh/malcontent-action`.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R57): Replaced all instances of `imjasonh/malcontent-action` with `chainguard-dev/malcontent-action` in example YAML configurations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R57) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R78) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R110) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R149)

### Repository metadata update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R16): Updated the `repository.url` field to point to the new repository URL under `chainguard-dev`.