### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,5 +1,8 @@
 name: Format Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/chainguard-dev/malcontent-action/security/code-scanning/10](https://github.com/chainguard-dev/malcontent-action/security/code-scanning/10)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow only performs read operations (e.g., checking formatting), the `contents: read` permission is sufficient. This change ensures that the `GITHUB_TOKEN` has the minimum required permissions, reducing the risk of unintended repository modifications.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional dependencies or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
