### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        if: github.actor == 'dependabot[bot]'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- Add GitHub workflow to automatically merge Dependabot pull requests
- Uses squash merge strategy for clean commit history
- Helps keep dependencies up-to-date without manual intervention

## Test plan
- [x] Workflow syntax is valid
- [x] Workflow will only trigger for Dependabot PRs
- [x] Auto-merge will use squash strategy

🤖 Generated with [Claude Code](https://claude.ai/code)